### PR TITLE
run dependabot twice a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,8 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "19:00"
-      timezone: "Europe/Vienna"
-    open-pull-requests-limit: 1
+      interval: "cron"
+      cronjob: "0 2 7,21 * *"
     cooldown:
       semver-patch-days: 5
       semver-minor-days: 7
@@ -25,20 +23,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "20:00"
-      timezone: "Europe/Vienna"
-    open-pull-requests-limit: 1
+      interval: "cron"
+      cronjob: "0 5 7,21 * *"
     cooldown:
       default-days: 7
     exclude-paths:
       - ".github/workflows/release.yml"
       - ".github/workflows/scan.yml"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
The old setup checked for updates every day and auto-merged them the same day. That didn't work well for fast-moving dependencies because the same package could be bumped on consecutive days as new eligible releases kept appearing.